### PR TITLE
[Fix] Resolve the bug causing the styling of the screen to break

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+key.json
 
 # dependencies
 /node_modules

--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@ Chrome extension to copy the current URL to the clipboard. \
 
 ## Usage
 
-- Click the extension icon
-- Use the following shortcut.
+* Click the extension icon
+* Use the following shortcut.
 
 ### Default Shortcut
 
-- Mac: `Cmd+Shift+C`
-- Windows/Linux: `Ctrl+Shift+C`
+* Mac: `Cmd+Shift+C`
+* Windows/Linux: `Ctrl+Shift+C`
 
  If the shortcut is conflicting with an existing one, you will be notified at install time. In that case, please change the shortcut.
  In the case of Google Chrome, `Cmd/Ctrl+Shift+C` is assigned to Inspect Elements, so you need to manually override it.
@@ -23,9 +23,9 @@ Chrome extension to copy the current URL to the clipboard. \
 
 ### Copy formats
 
-- Plain URL
-- Title + URL
-- Markdown link
-- Backlog link
+* Plain URL
+* Title + URL
+* Markdown link
+* Backlog link
 
 [Demo Video](https://www.youtube.com/watch?v=m7AEzk4cKF0)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
   <h1 style="color: hsl(, 100%, 50%);">URL Copy</h1>
 </div>
 
-Chrome extension to copy the current URL to the clipboard.
+Chrome extension to copy the current URL to the clipboard. \
+[Chrome Web Store link](https://chromewebstore.google.com/detail/url-copy/khfenepnobebagchdbalmfeafedaljki)
 
 ## Usage
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "url-copy",
   "displayName": "URL Copy",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "__MSG_description__",
   "author": "yuta-nishi",
   "homepage": "https://github.com/yuta-nishi/url-copy",

--- a/src/contents/index.tsx
+++ b/src/contents/index.tsx
@@ -1,10 +1,6 @@
 import type { PlasmoCSConfig, PlasmoGetStyle } from 'plasmo';
 import { useEffect, useState } from 'react';
 
-// Add tailwind css for shadcn/ui components
-// Without this, shadcn/ui components will not be displayed correctly
-import '~/style.css';
-
 import cssText from 'data-text:~/style.css';
 import { Toaster } from '~/components/ui/toaster';
 import { useToast } from '~/components/ui/use-toast';

--- a/src/style.css
+++ b/src/style.css
@@ -3,7 +3,8 @@
 @tailwind utilities;
 
 @layer base {
-  :root {
+  /** @see https://github.com/shadcn-ui/ui/issues/1064 */
+  :host {
     --background: 0 0% 100%;
     --foreground: 222.2 84% 4.9%;
 


### PR DESCRIPTION
## Overview

An unintended bug occurred due to applying `style.css` to the entire screen.

## Screenshot

* In the case of style distortion
<img width="800" alt="Screenshot 2024-02-25 at 4 07 05" src="https://github.com/yuta-nishi/url-copy/assets/91929233/2758ec1c-eb54-4c13-a4ef-1c10174b9ed3">

* In the case after resolving the style distortion
<img width="800" alt="Screenshot 2024-02-25 at 4 07 22" src="https://github.com/yuta-nishi/url-copy/assets/91929233/17ffb9af-56ea-4835-a7ef-6ec93a8a776b">
